### PR TITLE
fix running esbuild cli with deno

### DIFF
--- a/lib/deno/mod.ts
+++ b/lib/deno/mod.ts
@@ -215,7 +215,7 @@ const spawnNew: SpawnFn = (cmd, { args, stdin, stdout, stderr }) => {
  @@ -223,8 +224,8 @@ const spawnNew: SpawnFn = (cmd, { args, stdin, stdout, stderr }) => {
        // we can do.
        //
-       // See this for more info: https://github.com/evanw/esbuild/pull/3611
+       // See this for more info: https://github.com/khulnasoft/ezburn/pull/2
        await writer?.close()
        await reader?.cancel()
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixes the `spawnNew` function to handle `piped` stdio correctly.

- Replaces manual null checks with optional chaining for better readability.

- Corrects a typo in the `read` function assignment.

- Updates comments for clarity and references the correct GitHub issue.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.ts</strong><dd><code>Fix and improve `spawnNew` function in Deno module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/deno/mod.ts

<li>Adjusted handling of <code>piped</code> stdio in <code>spawnNew</code> function.<br> <li> Replaced manual null checks with optional chaining.<br> <li> Fixed a typo in the <code>read</code> function assignment.<br> <li> Updated comments for clarity and added correct GitHub issue reference.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/ezburn/pull/2/files#diff-4137e798fbdbbb936cff18521bd8e5d8880b4459586606b10ae583001213aa32">+15/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent unexpected runtime exceptions during process operations.
- **Chores**
  - Streamlined internal cleanup procedures for smoother termination and more reliable resource management.

These updates enhance overall stability during background operations, ensuring a more robust execution environment without altering public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->